### PR TITLE
Fix call to openapicmd in docs

### DIFF
--- a/docs/openapi-client-axios/bundling.md
+++ b/docs/openapi-client-axios/bundling.md
@@ -38,7 +38,7 @@ all unnecessary metadata from your openapi file before bundling for use with ope
 To create an optimized runtime version of your openapi definition:
 
 ```sh
-npx openapicmd read --strip openapi_client_axios openapi.json > openapi-runtime.json
+npx openapicmd read --strip openapi_client_axios --format=json openapi.json > openapi-runtime.json
 ```
 
 This file can then be included in your runtime bundle:

--- a/docs/openapi-client-axios/bundling.md
+++ b/docs/openapi-client-axios/bundling.md
@@ -38,7 +38,7 @@ all unnecessary metadata from your openapi file before bundling for use with ope
 To create an optimized runtime version of your openapi definition:
 
 ```sh
-npx openapicmd read --strip openapi_client_axios --format=json openapi.json > openapi-runtime.json
+npx openapicmd read --strip openapi_client_axios --format json openapi.json > openapi-runtime.json
 ```
 
 This file can then be included in your runtime bundle:


### PR DESCRIPTION
`openapicmd read` produces YAML output by default. The example in the docs is about using this output as a JSON import in JS - so obviously we have to generate JSON instead of YAML.