### PR TITLE
fix boilerplate link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ While the lightweight tRPC approach is optimal for teams just looking to build f
 - [x] Framework agnostic – works with your stack
 - [x] Lightweight - small frontend bundle + optimized for serverless cold starts
 - [x]  OpenAPI 3.x support
-- [x] [Samples](/docs/examples/boilerplate/) included
+- [x] [Samples](/docs/examples/boilerplate.md) included
 
 ## API First Cycle
 


### PR DESCRIPTION
The **boilerplate** link in the readme is not linked to any resource, it should be `https://github.com/openapistack/docs/blob/main/docs/examples/boilerplate.md` instead of `https://github.com/openapistack/docs/blob/main/docs/examples/boilerplate`