### PR TITLE
Fix AJV options link

### DIFF
--- a/docs/openapi-backend/api.md
+++ b/docs/openapi-backend/api.md
@@ -570,7 +570,7 @@ Type: `Document`
 
 #### Parameter: opts.ajvOpts
 
-Optional. The default AJV options to use for validation. See [available options](https://ajv.js.org/#options)
+Optional. The default AJV options to use for validation. See [available options](https://ajv.js.org/options.html)
 
 Type: `AjvOpts`
 


### PR DESCRIPTION
The link to AJV options in the doc is broken. Updated to include the active link