### PR TITLE
Add DEFRA as a verified openapi-backend user

### DIFF
--- a/src/data/users.ts
+++ b/src/data/users.ts
@@ -492,6 +492,19 @@ export const USERS: User[] = [
     tier: 'featured',
   },
   {
+    id: 'defra',
+    name: 'DEFRA',
+    website: 'https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs',
+    domain: 'defra.gov.uk',
+    logo: 'https://avatars.githubusercontent.com/DEFRA',
+    description:
+      'The UK Department for Environment, Food & Rural Affairs. Uses openapi-backend in the Wildlife Licensing Service for European Protected Species.',
+    packages: ['openapi-backend'],
+    githubLink: 'https://github.com/DEFRA/wildlife-licencing/blob/c7a594578c786fefb6018786d538399c228a55b3/packages/api/package.json#L41',
+    useCase: 'Powers the API layer of the wildlife licencing service (@defra/wls-api), which processes European Protected Species licence applications.',
+    tier: 'featured',
+  },
+  {
     id: 'polis',
     name: 'Polis',
     website: 'https://pol.is',


### PR DESCRIPTION
## Summary
- Adds DEFRA (UK Department for Environment, Food & Rural Affairs) to `src/data/users.ts` as a verified `openapi-backend` dependent.
- Verified via `packages/api/package.json` in DEFRA/wildlife-licencing (@defra/wls-api), which depends on openapi-backend@^5.0.0 and powers the Wildlife Licensing Service for European Protected Species.

## Test plan
- [x] `tsc --noEmit` shows no new errors introduced by this change
- [x] Entry follows the existing schema/style in `src/data/users.ts` (matches other government entries: bcgov, opetushallitus, helsingborg-stad)

---
_Generated by [Claude Code](https://claude.ai/code/session_017V63mmwRhWR2Knpc2Wv1CQ)_