### PR TITLE
docs: fix prose typos in openapi-backend docs

### DIFF
--- a/docs/examples/calling-apis.md
+++ b/docs/examples/calling-apis.md
@@ -23,7 +23,7 @@ Before starting, make sure to install `openapi-client-axios` and `axios` as depe
 npm i openapi-client-axios axios
 ```
 
-## Creating a client instace
+## Creating a client instance
 
 To call our API, we import `openapi-client-axios` and configure it by passing the OpenAPI definition URL:
 

--- a/docs/openapi-backend/api.md
+++ b/docs/openapi-backend/api.md
@@ -7,7 +7,7 @@ sidebar_position: 10
 ## Class OpenAPIBackend
 
 OpenAPIBackend is the main class you can interact with. You can create a new
-instance and initalize it with your OpenAPI document and handlers.
+instance and initialize it with your OpenAPI document and handlers.
 
 OpenAPIBackend is also the default import of the `openapi-backend` module. It
 can be imported in any of the following ways:
@@ -163,7 +163,7 @@ Type: `{ [operationId: string]: Handler }`
 
 ### .init()
 
-Initalizes the OpenAPIBackend instace for use.
+Initializes the OpenAPIBackend instance for use.
 
 1. Loads and parses the OpenAPI document passed in constructor options
 1. Validates the OpenAPI document
@@ -174,7 +174,7 @@ Initalizes the OpenAPIBackend instace for use.
 The `init()` method should be called right after creating a new instance of OpenAPIBackend. Although for ease of use,
 some methods like `handleRequest()` will call the method if the initalized member property is set to false.
 
-Returns the initalized OpenAPI backend instance.
+Returns the initialized OpenAPI backend instance.
 
 Example:
 
@@ -1013,7 +1013,7 @@ const operation: Operation = {
   },
   responses: {
     200: {
-      description: "Pet updated succesfully",
+      description: "Pet updated successfully",
     },
   },
 };

--- a/docs/openapi-backend/intro.md
+++ b/docs/openapi-backend/intro.md
@@ -64,7 +64,7 @@ api.register({
     res.status(400).json({ err: c.validation.errors }),
 });
 
-// initalize the backend
+// initialize the backend
 api.init();
 ```
 


### PR DESCRIPTION
Fixes prose typos in the openapi-backend documentation.

| File | Line | Fix |
|---|---|---|
| `docs/openapi-backend/api.md` | 10 | `initalize it` → `initialize it` |
| `docs/openapi-backend/api.md` | 166 | `Initalizes the OpenAPIBackend instace` → `Initializes … instance` (two typos) |
| `docs/openapi-backend/api.md` | 177 | `Returns the initalized OpenAPI backend instance` → `initialized` |
| `docs/openapi-backend/api.md` | 1016 | `"Pet updated succesfully"` → `successfully` |
| `docs/openapi-backend/intro.md` | 67 | `// initalize the backend` → `// initialize the backend` |
| `docs/examples/calling-apis.md` | 26 | `Creating a client instace` → `instance` |

### Deliberately left alone

Two occurrences of `initalized` on lines 171 and 175 of `api.md` are **not** changed:

```
1. Marks member property `initalized` to true
…will call the method if the initalized member property is set to false.
```

These name the real member property, which is spelled `initalized` in openapi-backend itself:

```ts
// src/backend.ts
public initalized: boolean;
```

"Correcting" the docs there would describe a property that doesn't exist. If you'd like the property itself renamed (with a deprecated alias), that's an API change and belongs in the `openapi-backend` repo rather than here — happy to open that separately if it's wanted.
