### PR TITLE
Fix 'initalized'/'initalised' typos in API docs

### DIFF
--- a/docs/openapi-backend/api.md
+++ b/docs/openapi-backend/api.md
@@ -168,11 +168,11 @@ Initializes the OpenAPIBackend instance for use.
 1. Loads and parses the OpenAPI document passed in constructor options
 1. Validates the OpenAPI document
 1. Builds validation schemas for all API operations
-1. Marks member property `initalized` to true
+1. Marks member property `initialized` to true
 1. Registers all [Operation Handlers](#operation-handlers) passed in constructor options
 
 The `init()` method should be called right after creating a new instance of OpenAPIBackend. Although for ease of use,
-some methods like `handleRequest()` will call the method if the initalized member property is set to false.
+some methods like `handleRequest()` will call the method if the initialized member property is set to false.
 
 Returns the initialized OpenAPI backend instance.
 

--- a/docs/openapi-client-axios/api.md
+++ b/docs/openapi-client-axios/api.md
@@ -84,14 +84,14 @@ const api = new OpenAPIClientAxios({
 
 ### .init()
 
-Initalizes OpenAPIClientAxios
+Initializes OpenAPIClientAxios
 
 Returns a promise of the created member axios instance.
 
 1. Parses the input definition into a JS object. If the input definition is a URL, it will be resolved
 2. Dereferences the definition for use.
 3. Creates the member axios instance
-4. Sets `api.initialised = true` and returns the created axios instance
+4. Sets `api.initialized = true` and returns the created axios instance
 
 Example:
 ```javascript
@@ -102,7 +102,7 @@ await api.init();
 
 Synchronous version of [`.init()`](#init)
 
-Initalizes OpenAPIClientAxios and creates the axios client instance.
+Initializes OpenAPIClientAxios and creates the axios client instance.
 
 Note: Only works when the input definition is a valid OpenAPI v3 object.
 
@@ -113,7 +113,7 @@ api.initSync();
 
 ### .getClient()
 
-Returns a promise of the member axios instance. Will run .init() if API is not initalised yet.
+Returns a promise of the member axios instance. Will run .init() if API is not initialised yet.
 
 Example:
 ```javascript
@@ -185,9 +185,9 @@ Type: `OperationMethodArguments`
 
 Creates a new axios instance, extends it and returns it.
 
-While initalising with [`.init()`](#init) or [.initSync()](#initsync) OpenAPIClientAxios calls this function to create the member client.
+While initialising with [`.init()`](#init) or [.initSync()](#initsync) OpenAPIClientAxios calls this function to create the member client.
 
-Note: Requires the API to be initalised first if run outside of .init() methods.
+Note: Requires the API to be initialised first if run outside of .init() methods.
 
 ### .getAxiosConfigForOperation(operation, args)
 
@@ -216,7 +216,7 @@ Type: `OperationMethodArguments`
 
 ## Axios Client Instance
 
-When OpenAPIClientAxios is initalised, a member
+When OpenAPIClientAxios is initialised, a member
 [axios client instance](https://github.com/axios/axios#creating-an-instance) is created.
 
 The client instance can be accessed either directly via `api.client` getter, or `api.getClient()`.


### PR DESCRIPTION
## Summary

Fixes misspellings of "initialized" across the API reference docs, matching the property rename in openapistack/openapi-backend#961.

- `docs/openapi-backend/api.md`: references to the misspelled `initalized` member property now say `initialized`, matching the corrected property name in openapi-backend
- `docs/openapi-client-axios/api.md`: fixes "Initalizes" (×2), "initalised" (×3), and "initalising" prose typos, and corrects `api.initialised = true` → `api.initialized = true` to match the actual property name in the openapi-client-axios source

A case-insensitive grep for `inital` across `docs/` now comes back clean.